### PR TITLE
Improve CI logs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,7 +25,7 @@ jobs:
       - run:
           name: "Print Logs"
           command: |
-            docker-compose -f deploy/docker-compose.default.yml -f deploy/docker-compose.test.yml logs bm-app
+            docker-compose -f deploy/docker-compose.default.yml -f deploy/test/docker-compose.test.yml logs bm-app
 
   # SSHs into our server and runs deploy_prod.sh
   deploy_prod:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,6 +22,10 @@ jobs:
           name: "Run Tests"
           command: |
             make test
+      - run:
+          name: "Print Logs"
+          command: |
+            docker-compose -f deploy/docker-compose.default.yml -f deploy/docker-compose.dev.yml logs bm-app
 
   # SSHs into our server and runs deploy_prod.sh
   deploy_prod:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,7 +25,7 @@ jobs:
       - run:
           name: "Print Logs"
           command: |
-            docker-compose -f deploy/docker-compose.default.yml -f deploy/docker-compose.dev.yml logs bm-app
+            docker-compose -f deploy/docker-compose.default.yml -f deploy/docker-compose.test.yml logs bm-app
 
   # SSHs into our server and runs deploy_prod.sh
   deploy_prod:


### PR DESCRIPTION
Docker kinda obscures logs so when CI failed it wouldn't say why, just that it did.  Now it should print out whatever we log in our app once it runs.